### PR TITLE
Added Pre Execution Security Policy

### DIFF
--- a/src/CodingMonkey.CodeExecutor/PreExecutionSecurity.cs
+++ b/src/CodingMonkey.CodeExecutor/PreExecutionSecurity.cs
@@ -1,0 +1,52 @@
+﻿namespace CodingMonkey.CodeExecutor
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+
+    public class PreExecutionSecurity
+    {
+        /// <summary>
+        /// A list of namespaces which are allowed to be included in using statements by
+        /// user submitted code.
+        /// </summary>
+        private static readonly IList<string> AllowedNamespaces = new ReadOnlyCollection<string>
+            (new List<string>()
+                 {
+                     "System",
+                     "System.Collections.Generic"
+                 });
+
+        public string SanitiseCode(string codeToSanitise)
+        {
+            string sanitisedCode;
+
+            sanitisedCode = SanitiseUsings(codeToSanitise);
+
+            return sanitisedCode;
+        }
+
+        private string SanitiseUsings(string codeToSanitise)
+        {
+            string sanitisedCode = codeToSanitise;
+
+            const string UsingPattern = "using.+;";
+            sanitisedCode = Regex.Replace(sanitisedCode, UsingPattern, "");
+
+            IList<string> usingStatements = this.GetAllowedUsingStatements();
+
+            string usingStatementsFlaterned = string.Join(Environment.NewLine, usingStatements);
+
+            sanitisedCode = usingStatementsFlaterned + Environment.NewLine + sanitisedCode;
+
+            return sanitisedCode;
+        }
+
+        private IList<string> GetAllowedUsingStatements()
+        {
+            return AllowedNamespaces.Select(x => x = "using " + x + ";").ToList();
+        }
+    }
+}

--- a/src/CodingMonkey.CodeExecutor/project.json
+++ b/src/CodingMonkey.CodeExecutor/project.json
@@ -16,6 +16,7 @@
     "System.Dynamic.Runtime": "4.0.10",
     "Microsoft.CSharp": "4.0.0",
     "Newtonsoft.Json": "8.0.2",
-    "System.Collections": "4.0.11-beta-23516"
+    "System.Collections": "4.0.11-beta-23516",
+    "System.Text.RegularExpressions": "4.0.11-beta-23516"
   }
 }


### PR DESCRIPTION
GItHub Issue #26 

Before running or compiling any code this code should... remove any using statements from the code and replace them with approved using statements. At the moment this all lives in code. I think longer term this should live in DB as there is likely to be more detail for this like stopwords (words if found in code to stop execution) or other details I have not thought of yet.
