### PR TITLE
Security - Blacklist for banned Namespaces

### DIFF
--- a/src/CodingMonkey.CodeExecutor/CodingMonkeyMetadataReferenceResolver.cs
+++ b/src/CodingMonkey.CodeExecutor/CodingMonkeyMetadataReferenceResolver.cs
@@ -1,0 +1,41 @@
+﻿namespace CodingMonkey.CodeExecutor
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Globalization;
+    using System.Reflection;
+    using System.Text;
+
+    using Microsoft.CodeAnalysis;
+    using System.Linq;
+
+    using Microsoft.CodeAnalysis.Scripting;
+
+    public class CodingMonkeyMetadataReferenceResolver : MetadataReferenceResolver
+    {
+        private MetadataReferenceResolver _defaultResolver = ScriptOptions.Default.MetadataResolver;
+
+        public override bool ResolveMissingAssemblies => false;
+
+        public override bool Equals(object other)
+        {
+            return this._defaultResolver.Equals(other);
+        }
+
+        public override int GetHashCode() => _defaultResolver.GetHashCode();
+
+        public override ImmutableArray<PortableExecutableReference> ResolveReference(
+            string reference,
+            string baseFilePath,
+            MetadataReferenceProperties properties)
+        {
+           return this._defaultResolver.ResolveReference(reference, baseFilePath, properties);
+        }
+
+        public override PortableExecutableReference ResolveMissingAssembly(MetadataReference definition, AssemblyIdentity referenceIdentity)
+        {
+            return null;
+        }
+    }
+}

--- a/src/CodingMonkey.CodeExecutor/project.json
+++ b/src/CodingMonkey.CodeExecutor/project.json
@@ -17,6 +17,7 @@
     "Microsoft.CSharp": "4.0.0",
     "Newtonsoft.Json": "8.0.2",
     "System.Collections": "4.0.11-beta-23516",
-    "System.Text.RegularExpressions": "4.0.11-beta-23516"
+    "System.Text.RegularExpressions": "4.0.11-beta-23516",
+    "System.Diagnostics.Contracts": "4.0.1-beta-23516"
   }
 }


### PR DESCRIPTION
Github issue #26 
# Description

Created a security black list for namespaces. This is because we need to include the core dlls but some code within them is still dangerous to us. Such as IO and Reflection. So this code searches through mscorlib and systemcore and creates a blacklist of all the namespaces excluding the ones on the whitelist.

Once the black list has been created the user submitted code is then run through the list and any blacklisted namespaces in the code are replaced with nothing.

I know blacklists are typically the wrong way to go with security but I am unsure of a better solution. I can't remove the dlls as we need some of the functionality they bring. This way at least the blacklist is 'dynamic' in a sense - if more types are added to the core dlls then they will just go on the blacklist. So it is all still driven by a whitelist.

Also added my own MetadataReferenceResolver - this is used by Rosyln to find references and assemblies. The one used internally ([RuntimeMetadataReferenceResolver](http://source.roslyn.io/#Microsoft.CodeAnalysis.Scripting/Hosting/Resolvers/RuntimeMetadataReferenceResolver.cs,289e04c9d564ce60) defaults to trying to find missing assemblies. I have switched this off!
