### PR TITLE
Moved the common frontend authentication code into its own class

### DIFF
--- a/src/CodingMonkey/src/admin/exercise-category/details.js
+++ b/src/CodingMonkey/src/admin/exercise-category/details.js
@@ -3,18 +3,15 @@ import {HttpClient, json} from 'aurelia-fetch-client';
 import {Router} from 'aurelia-router';
 import 'fetch';
 import toastr from 'toastr';
+import {Authentication} from './../../authentication/authentication.js';
 
 @inject(HttpClient, Router)
 export class details {
     constructor(http, router) {
         this.appRouter = router;
+
         // Check there is a logged in user or kick them to homepage
-        var currentUser = this.getCurrentUserInSessionStorage();
-
-        if (!currentUser.isLoggedIn) {
-            this.appRouter.navigate("/");
-        }
-
+        new Authentication(this.appRouter).verifyUserLoggedIn();
         var loc = window.location;
         
         this.heading = "Exercise Category Details";
@@ -86,12 +83,5 @@ export class details {
     
     goToExerciseCategoryList() {
         this.appRouter.navigate("admin/exercise/categories");
-    }
-
-    getCurrentUserInSessionStorage() {
-        let currentUserRaw = sessionStorage.getItem("currentUser");
-        let currentUser = JSON.parse(currentUserRaw);
-
-        return currentUser;
     }
 }

--- a/src/CodingMonkey/src/admin/exercise-category/list.js
+++ b/src/CodingMonkey/src/admin/exercise-category/list.js
@@ -5,17 +5,15 @@ import 'fetch';
 import {DialogService} from 'aurelia-dialog';
 import {DialogPrompt} from '../../dialog-prompt';
 import toastr from 'toastr';
+import {Authentication} from './../../authentication/authentication.js';
 
 @inject(HttpClient, DialogService, Router)
 export class list {
     constructor(http, dialogService, router) {
         this.appRouter = router;
+        
         // Check there is a logged in user or kick them to homepage
-        var currentUser = this.getCurrentUserInSessionStorage();
-
-        if (!currentUser.isLoggedIn) {
-            this.appRouter.navigate("/");
-        }
+        new Authentication(this.appRouter).verifyUserLoggedIn();
 
         this.dialogService = dialogService;
 
@@ -92,12 +90,5 @@ export class list {
                 });
             }
         });
-    }
-
-    getCurrentUserInSessionStorage() {
-        let currentUserRaw = sessionStorage.getItem("currentUser");
-        let currentUser = JSON.parse(currentUserRaw);
-
-        return currentUser;
     }
 }

--- a/src/CodingMonkey/src/admin/exercise-category/update.js
+++ b/src/CodingMonkey/src/admin/exercise-category/update.js
@@ -3,17 +3,15 @@ import {HttpClient, json} from 'aurelia-fetch-client';
 import {Router} from 'aurelia-router';
 import 'fetch';
 import toastr from 'toastr';
+import {Authentication} from './../../authentication/authentication.js';
 
 @inject(HttpClient, Router)
 export class update {
     constructor(http, router) {
         this.appRouter = router;
+        
         // Check there is a logged in user or kick them to homepage
-        var currentUser = this.getCurrentUserInSessionStorage();
-
-        if (!currentUser.isLoggedIn) {
-            this.appRouter.navigate("/");
-        }
+        new Authentication(this.appRouter).verifyUserLoggedIn();
 
         var loc = window.location;
         
@@ -53,34 +51,27 @@ export class update {
               this.heading = "Update Exercise Category: " + this.vm.exerciseCategory.name;
           })
           .catch(err => {
-              this.notify.error("Failed to get Exercise Category.")
-          });
+                this.notify.error("Failed to get Exercise Category.");
+            });
     }
     
-    updateExerciseCategory() {        
+    updateExerciseCategory() {
         this.http.fetch('update/' + this.vm.exerciseCategory.id, {
-            method: 'post',
-            body: json({
-                Name: this.vm.exerciseCategory.name,
-                Description: this.vm.exerciseCategory.description,
-                ExerciseIds: this.vm.exerciseCategory.exerciseids
+                method: 'post',
+                body: json({
+                    Name: this.vm.exerciseCategory.name,
+                    Description: this.vm.exerciseCategory.description,
+                    ExerciseIds: this.vm.exerciseCategory.exerciseids
+                })
             })
-        })
-        .then(response => response.json())
-        .then(data => {
-            this.notify.success("Updated Exercise Category '" + this.vm.exerciseCategory.name + "'");
-            this.appRouter.navigate("admin/exercise/categories/" + this.vm.exerciseCategory.id);
-        })
-        .catch(err => {
-            this.notify.error("Update Exercise Category failed.")
-        })
-        
-    }
+            .then(response => response.json())
+            .then(data => {
+                this.notify.success("Updated Exercise Category '" + this.vm.exerciseCategory.name + "'");
+                this.appRouter.navigate("admin/exercise/categories/" + this.vm.exerciseCategory.id);
+            })
+            .catch(err => {
+                this.notify.error("Update Exercise Category failed.");
+            });
 
-    getCurrentUserInSessionStorage() {
-        let currentUserRaw = sessionStorage.getItem("currentUser");
-        let currentUser = JSON.parse(currentUserRaw);
-
-        return currentUser;
     }
 }

--- a/src/CodingMonkey/src/admin/exercise/create.js
+++ b/src/CodingMonkey/src/admin/exercise/create.js
@@ -3,6 +3,7 @@ import {HttpClient, json} from 'aurelia-fetch-client';
 import {Router} from 'aurelia-router';
 import 'fetch';
 import toastr from 'toastr';
+import {Authentication} from './../../authentication/authentication.js';
 
 @inject(HttpClient, Router)
 export class create {
@@ -10,11 +11,7 @@ export class create {
         this.appRouter = router;
 
         // Check there is a logged in user or kick them to homepage
-        var currentUser = this.getCurrentUserInSessionStorage();
-
-        if (!currentUser.isLoggedIn) {
-            this.appRouter.navigate("/");
-        }
+        new Authentication(this.appRouter).verifyUserLoggedIn();
 
         var loc = window.location;
         
@@ -179,12 +176,5 @@ export class create {
             this.vm.exerciseTemplate.mainMethodSignature = this.vm.exerciseTemplate.initialCode.match(methodSignatureRegexPattern)[0];
             this.vm.exerciseTemplate.mainMethodName = this.vm.exerciseTemplate.mainMethodSignature.match(methodNameRegexPattern);
         }
-    }
-
-    getCurrentUserInSessionStorage() {
-        let currentUserRaw = sessionStorage.getItem("currentUser");
-        let currentUser = JSON.parse(currentUserRaw);
-
-        return currentUser;
     }
 }

--- a/src/CodingMonkey/src/admin/exercise/details.js
+++ b/src/CodingMonkey/src/admin/exercise/details.js
@@ -3,6 +3,7 @@ import {HttpClient, json} from 'aurelia-fetch-client';
 import {Router} from 'aurelia-router';
 import 'fetch';
 import toastr from 'toastr';
+import {Authentication} from './../../authentication/authentication.js';
 
 @inject(HttpClient, Router)
 export class details {
@@ -10,11 +11,7 @@ export class details {
         this.appRouter = router;
 
         // Check there is a logged in user or kick them to homepage
-        var currentUser = this.getCurrentUserInSessionStorage();
-
-        if (!currentUser.isLoggedIn) {
-            this.appRouter.navigate("/");
-        }
+        new Authentication(this.appRouter).verifyUserLoggedIn();
 
         var loc = window.location;
         
@@ -118,12 +115,5 @@ export class details {
     
     goToExerciseList() {
         this.appRouter.navigate("admin/exercises");
-    }
-
-    getCurrentUserInSessionStorage() {
-        let currentUserRaw = sessionStorage.getItem("currentUser");
-        let currentUser = JSON.parse(currentUserRaw);
-
-        return currentUser;
     }
 }

--- a/src/CodingMonkey/src/admin/exercise/list.js
+++ b/src/CodingMonkey/src/admin/exercise/list.js
@@ -5,6 +5,7 @@ import {Router} from 'aurelia-router';
 import {DialogService} from 'aurelia-dialog';
 import {DialogPrompt} from '../../dialog-prompt';
 import toastr from 'toastr';
+import {Authentication} from './../../authentication/authentication.js';
 
 @inject(HttpClient, DialogService, Router)
 export class list {
@@ -14,11 +15,7 @@ export class list {
         this.appRouter = router;
 
         // Check there is a logged in user or kick them to homepage
-        var currentUser = this.getCurrentUserInSessionStorage();
-
-        if (!currentUser.isLoggedIn) {
-            this.appRouter.navigate("/");
-        }
+        new Authentication(this.appRouter).verifyUserLoggedIn();
 
         this.notify = toastr;
         this.notify.options.progressBar = true;
@@ -96,12 +93,5 @@ export class list {
     
     goToCreateExercise() {
         this.appRouter.navigate("admin/exercise/create");
-    }
-
-    getCurrentUserInSessionStorage() {
-        let currentUserRaw = sessionStorage.getItem("currentUser");
-        let currentUser = JSON.parse(currentUserRaw);
-
-        return currentUser;
     }
 }

--- a/src/CodingMonkey/src/admin/exercise/update.js
+++ b/src/CodingMonkey/src/admin/exercise/update.js
@@ -3,6 +3,7 @@ import {HttpClient, json} from 'aurelia-fetch-client';
 import {Router} from 'aurelia-router';
 import 'fetch';
 import toastr from 'toastr';
+import {Authentication} from './../../authentication/authentication.js';
 
 @inject(HttpClient, Router)
 export class update {
@@ -10,11 +11,7 @@ export class update {
         this.appRouter = router;
 
         // Check there is a logged in user or kick them to homepage
-        var currentUser = this.getCurrentUserInSessionStorage();
-
-        if (!currentUser.isLoggedIn) {
-            this.appRouter.navigate("/");
-        }
+        new Authentication(this.appRouter).verifyUserLoggedIn();
 
         var loc = window.location;
         
@@ -195,12 +192,5 @@ export class update {
         } else {
             return true;
         }
-    }
-
-    getCurrentUserInSessionStorage() {
-        let currentUserRaw = sessionStorage.getItem("currentUser");
-        let currentUser = JSON.parse(currentUserRaw);
-
-        return currentUser;
     }
 }

--- a/src/CodingMonkey/src/admin/test/create.js
+++ b/src/CodingMonkey/src/admin/test/create.js
@@ -3,17 +3,15 @@ import {HttpClient, json} from 'aurelia-fetch-client';
 import {Router} from 'aurelia-router';
 import 'fetch';
 import toastr from 'toastr';
+import {Authentication} from './../../authentication/authentication.js';
 
 @inject(HttpClient, Router)
 export class create {
     constructor(http, router) {
         this.appRouter = router;
-        // Check there is a logged in user or kick them to homepage
-        var currentUser = this.getCurrentUserInSessionStorage();
 
-        if (!currentUser.isLoggedIn) {
-            this.appRouter.navigate("/");
-        }
+        // Check there is a logged in user or kick them to homepage
+        new Authentication(this.appRouter).verifyUserLoggedIn();
 
         var loc = window.location;
         
@@ -165,12 +163,5 @@ export class create {
     
     goToTestList() {
         this.appRouter.navigate("admin/exercise/" + this.vm.exercise.id + "/tests");
-    }
-
-    getCurrentUserInSessionStorage() {
-        let currentUserRaw = sessionStorage.getItem("currentUser");
-        let currentUser = JSON.parse(currentUserRaw);
-
-        return currentUser;
     }
 }

--- a/src/CodingMonkey/src/admin/test/details.js
+++ b/src/CodingMonkey/src/admin/test/details.js
@@ -3,17 +3,15 @@ import {HttpClient, json} from 'aurelia-fetch-client';
 import {Router} from 'aurelia-router';
 import 'fetch';
 import toastr from 'toastr';
+import {Authentication} from './../../authentication/authentication.js';
 
 @inject(HttpClient, Router)
 export class details {
     constructor(http, router) {
         this.appRouter = router;
+        
         // Check there is a logged in user or kick them to homepage
-        var currentUser = this.getCurrentUserInSessionStorage();
-
-        if (!currentUser.isLoggedIn) {
-            this.appRouter.navigate("/");
-        }
+        new Authentication(this.appRouter).verifyUserLoggedIn();
 
         var loc = window.location;
         
@@ -69,18 +67,11 @@ export class details {
               }
           })
           .catch(err => {
-              this.notify.error("Failed to get test.")
-          });
+                this.notify.error("Failed to get test.");
+            });
     }
     
     goToTestList() {
         this.appRouter.navigate("admin/exercise/" + this.exerciseId + "/tests");
-    }
-
-    getCurrentUserInSessionStorage() {
-        let currentUserRaw = sessionStorage.getItem("currentUser");
-        let currentUser = JSON.parse(currentUserRaw);
-
-        return currentUser;
     }
 }

--- a/src/CodingMonkey/src/admin/test/list.js
+++ b/src/CodingMonkey/src/admin/test/list.js
@@ -5,17 +5,15 @@ import {Router} from 'aurelia-router';
 import {DialogService} from 'aurelia-dialog';
 import {DialogPrompt} from '../../dialog-prompt';
 import toastr from 'toastr';
+import {Authentication} from './../../authentication/authentication.js';
 
 @inject(HttpClient, DialogService, Router)
 export class list {
     constructor(http, dialogService, router) {
         this.appRouter = router;
+        
         // Check there is a logged in user or kick them to homepage
-        var currentUser = this.getCurrentUserInSessionStorage();
-
-        if (!currentUser.isLoggedIn) {
-            this.appRouter.navigate("/");
-        }
+        new Authentication(this.appRouter).verifyUserLoggedIn();
 
         this.dialogService = dialogService;
 
@@ -117,12 +115,5 @@ export class list {
     
     goToExercise() {
         this.appRouter.navigate("admin/exercise/" + this.exerciseId);
-    }
-
-    getCurrentUserInSessionStorage() {
-        let currentUserRaw = sessionStorage.getItem("currentUser");
-        let currentUser = JSON.parse(currentUserRaw);
-
-        return currentUser;
     }
 }

--- a/src/CodingMonkey/src/admin/test/update.js
+++ b/src/CodingMonkey/src/admin/test/update.js
@@ -3,17 +3,15 @@ import {HttpClient, json} from 'aurelia-fetch-client';
 import {Router} from 'aurelia-router';
 import 'fetch';
 import toastr from 'toastr';
+import {Authentication} from './../../authentication/authentication.js';
 
 @inject(HttpClient, Router)
 export class create {
     constructor(http, router) {
         this.appRouter = router;
+        
         // Check there is a logged in user or kick them to homepage
-        var currentUser = this.getCurrentUserInSessionStorage();
-
-        if (!currentUser.isLoggedIn) {
-            this.appRouter.navigate("/");
-        }
+        new Authentication(this.appRouter).verifyUserLoggedIn();
 
         var loc = window.location;
         
@@ -91,18 +89,18 @@ export class create {
     
     getExercise(exerciseId) {
         this.http.baseUrl = this.baseUrl + '/api/Exercise/';
-        
+
         this.http.fetch('details/' + exerciseId)
-          .then(response => response.json())
-          .then(data => {
-              this.vm.exercise.id = data.Id
-              this.vm.exercise.name = data.Name;
-              this.vm.exercise.guidance = data.Guidance;
-              this.vm.exercise.categoryids = data.CategoryIds;
-          })
-          .catch(err => {
-              this.notify.error("Failed to get Exercise for Exercise Test.")
-          })
+            .then(response => response.json())
+            .then(data => {
+                this.vm.exercise.id = data.Id;
+                this.vm.exercise.name = data.Name;
+                this.vm.exercise.guidance = data.Guidance;
+                this.vm.exercise.categoryids = data.CategoryIds;
+            })
+            .catch(err => {
+                this.notify.error("Failed to get Exercise for Exercise Test.");
+            });
     }
     
     getExerciseTemplate(exerciseId) {
@@ -183,12 +181,5 @@ export class create {
     
     goToTestList() {
         this.appRouter.navigate("admin/exercise/" + this.vm.exercise.id + "/tests");
-    }
-
-    getCurrentUserInSessionStorage() {
-        let currentUserRaw = sessionStorage.getItem("currentUser");
-        let currentUser = JSON.parse(currentUserRaw);
-
-        return currentUser;
     }
 }

--- a/src/CodingMonkey/src/authentication/authentication.js
+++ b/src/CodingMonkey/src/authentication/authentication.js
@@ -1,0 +1,20 @@
+﻿export class Authentication {
+    constructor(router) {
+        this.appRouter = router;
+    }
+
+    verifyUserLoggedIn() {
+        var currentUser = Authentication.getCurrentUserInSessionStorage();
+
+        if (!currentUser.isLoggedIn) {
+            this.appRouter.navigate("/");
+        }
+    }
+
+    static getCurrentUserInSessionStorage() {
+        let currentUserRaw = sessionStorage.getItem("currentUser");
+        let currentUser = JSON.parse(currentUserRaw);
+
+        return currentUser;
+    }
+}

--- a/src/CodingMonkey/src/main.js
+++ b/src/CodingMonkey/src/main.js
@@ -3,7 +3,6 @@ import 'bootstrap';
 export function configure(aurelia) {
   aurelia.use
     .standardConfiguration()
-    .developmentLogging()
     .plugin('aurelia-dialog');
 
   //Uncomment the line below to enable animation.


### PR DESCRIPTION
Github Issue #45 
# Description

Moved the duplicated code into its own class and reused throughout. Also switched off development logging for aurelia. Replace Aurelia use with:

```
aurelia.use
     .standardConfiguration()
     .developmentLogging()      
     .plugin('aurelia-dialog');
```

To add it back in.
